### PR TITLE
Add Generations section with starter code

### DIFF
--- a/generation/cost-estimation.md
+++ b/generation/cost-estimation.md
@@ -1,0 +1,34 @@
+## Cost Estimation Functions
+
+This function takes an input string and outputs an estimate cost for that string. Cohere charges based on generation units, where one generation unit is up to 1k characters. Consider using this function to estimate previously run prompts and output costs, or to process multiple prompts to find the most cost effective one.
+
+### `str_to_cost`
+
+This function takes a string and model type specification and outputs an estimated cost for processing that string with the corresponding generative endpoint.
+
+### Parameters
+
+* `prompt` (`str`): A string that may be passed to co.generate
+* `model` (`str`): Default or Custom model type
+
+### Returns
+
+* `float`: An estimate of cost in dollars for the prompt to be processed by the given model type.
+
+### Example Usage
+
+```python
+>>> import math
+
+>>> def str_to_cost(prompt, model="default"):
+...     prompt_chars = len(prompt)
+...     num_units = math.ceil(prompt_chars/1000)
+...     if model == "custom":
+...         return num_units * (5/1000)
+...     else:
+...         return num_units * (2.5/1000)
+
+>>> str_to_cost("Write me a poem about dogs")
+0.0025
+
+```

--- a/generation/rapid-prompt-iteration
+++ b/generation/rapid-prompt-iteration
@@ -1,0 +1,46 @@
+# Testing Prompts Quickly
+
+When developing applications with generative end points, it's important to setup a development environment where you can quickly test prompts for a given model.
+In this notebook, we'll demonstrate how to create such a demo application, which can help accelerate innovation with these APIs.
+
+# Streamlit Prototyping
+
+Here, we'll demonstrate how to use Streamlit, Langchain, and Pandas packages to create a rapid prompt iteration environment. This app allows you to submit prompts, and log their results to a history dataframe while you work.
+
+``` python
+import streamlit as st
+from langchain.llms import Cohere
+import pandas as pd
+
+# Adjust this global instantiation of the Cohere api to set parameters across calls
+
+llm = Cohere()
+
+if "output" not in st.session_state:
+    st.session_state["output"] = ""
+
+if "history" not in st.session_state:
+    st.session_state["history"] = pd.DataFrame(columns = ["input_prompt", "completion"])
+
+st.title("Rapid Prompt Iteration with Streamlit, Cohere, and Langchain")
+
+
+prompt = st.text_input(label = "Write your prompt here!", value = "")
+
+def return_completion(prompt):
+    st.session_state.output = llm(prompt)
+
+gen_result = st.button("Generate Completion")
+
+if prompt != "" and gen_result:
+    result = llm(prompt)
+    result_dict = {
+        "input_prompt": prompt,
+        "completion": result
+    }
+    st.session_state["history"] = pd.concat([st.session_state["history"], pd.DataFrame([result_dict])],
+    ignore_index=True)
+
+st.write(st.session_state.history)
+
+```

--- a/generation/rapid-prompt-iteration.py
+++ b/generation/rapid-prompt-iteration.py
@@ -1,0 +1,36 @@
+import streamlit as st
+from langchain.llms import Cohere
+import pandas as pd
+
+# Adjust this global instantiation of the Cohere api to set parameters across calls
+
+llm = Cohere()
+
+if "output" not in st.session_state:
+    st.session_state["output"] = ""
+
+if "history" not in st.session_state:
+    st.session_state["history"] = pd.DataFrame(columns = ["input_prompt", "completion"])
+
+st.title("Rapid Prompt Iteration with Streamlit, Cohere, and Langchain")
+
+
+prompt = st.text_input(label = "Write your prompt here!", value = "")
+
+def return_completion(prompt):
+    st.session_state.output = llm(prompt)
+
+gen_result = st.button("Generate Completion")
+
+if prompt != "" and gen_result:
+    result = llm(prompt)
+    result_dict = {
+        "input_prompt": prompt,
+        "completion": result
+    }
+    st.session_state["history"] = pd.concat([st.session_state["history"], pd.DataFrame([result_dict])],
+    ignore_index=True)
+
+st.write(st.session_state.history)
+
+


### PR DESCRIPTION
Hi Elle!
Added two examples under a new generation file. Contains code to estimate cost of prompts, and code to rapidly create a streamlit app to test prompt development locally or in a private deployment on streamlit cloud.